### PR TITLE
Fix usage of 'dig' to actually use the own implementation

### DIFF
--- a/lib/graphql/result_cache/context_config.rb
+++ b/lib/graphql/result_cache/context_config.rb
@@ -39,7 +39,7 @@ module GraphQL
       def cache_or_amend_result result, config_of_query
         config_of_query.each do |config|
           if config[:result].nil?
-            cache.write config[:key], result.dig('data', *config[:path]), cache_write_options.merge(expires_in: expires_in)
+            cache.write config[:key], dig(result, 'data', *config[:path]), cache_write_options.merge(expires_in: expires_in)
           else
             # result already got from cache, need to amend to response
             result_hash = result.to_h

--- a/spec/graphql/result_cache/context_config_spec.rb
+++ b/spec/graphql/result_cache/context_config_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe GraphQL::ResultCache::ContextConfig do
     context 'with result cache on query' do
       context 'without cached result' do
         after do
-          expect(result).to receive(:dig).with('data', *path).and_return 'result_on_path'
+          expect(subject).to receive(:dig).with(result, 'data', *path).and_return 'result_on_path'
           expect(cache).to receive(:write).with(cache_key, 'result_on_path', expires_in: 3600)
           expect(subject.process(result)).to eq result
         end
@@ -97,7 +97,7 @@ RSpec.describe GraphQL::ResultCache::ContextConfig do
 
       it 'should return result without process' do
         subject.value[other_query] = [{path: path, key: cache_key, result: nil}]
-        expect(result).to receive(:dig).never
+        expect(subject).to receive(:dig).never
         expect(cache).to receive(:write).never
         expect(subject.process(result)).to eq result
       end


### PR DESCRIPTION
Hi @saharaying 

In https://github.com/saharaying/graphql-result_cache/commit/4fba5f69afacd4620c2ba8bb1433aa9221c9c0cf support for Ruby 2.2 was introduced (thanks for that!).

With it came a backport of the `dig` method; though the code was actually not properly using it, still relying on the `dig` from the stdlib.

This PR fixes that.